### PR TITLE
new whatsapp version + support for camera capturing display

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update \
 	libgl1-mesa-dev \
 	wget \
 	unzip \
-	openjdk-8-jdk
+	openjdk-8-jdk \
+	ffmpeg
 #	v4l2loopback
 
 # Install and enable KVM
@@ -42,9 +43,11 @@ RUN wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -P
 COPY supervisord.conf /etc/supervisor/conf.d
 COPY whatsapp.apk /app
 COPY start-avd.sh /app
+COPY start-avd-with-cam.sh /app
 COPY avd.desktop /app
 
 RUN chmod +x /app/start-avd.sh
+RUN chmod +x /app/start-avd-with-cam.sh
 RUN chmod +x /app/avd.desktop
 
 # Create directory to save AVD snapshots

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ At the moment the Docker entrypoint CMD/Supervisord isn't configuring the AVD. F
 
 `/app/start-avd.sh`
 
+In case you would like to start it with camera support (will take the screen from the VM as camera input):
+
+`/app/start-avd-with-cam.sh`
+
+After Android started, open your browser and open WhatsAppWeb or if you have the Matrix WhatsAppBridgeBot send login.
+This should delivever you the QR code, now open in WhatsApp under option the "WhatsAppWeb", move with the Firefox window with QR code that it fits in the camera field of whatsapp.
+Depending on camera position it helps to rotate your mobile phone with the emulator buttons to be able to catch the QR code.
+
+For more detail to bridge with matrix look here: https://matrix.org/docs/guides/whatsapp-bridging-mautrix-whatsapp 
+
 Please feel welcome to submit a pull-request to fix it!
 
 ## Further Development

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,11 +16,14 @@ services:
       environment:
         - HTTP_PASSWORD=secret
         - VNC_PASSWORD=secret
+      cap_add:
+        - ALL
       ports:
         - 6080:80
         - 5900:5900
       volumes:
         - ./snapshots:/app/snapshots
         - ./avd:/root/.android/avd
+        - /lib/modules:/lib/modules:ro
 volumes:
   avd:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -e
+
+#set -e
+export QTWEBENGINE_DISABLE_SANDBOX=1
 
 # Create the kvm node (required --privileged)
 if [ ! -e /dev/kvm ]; then

--- a/start-avd-with-cam.sh
+++ b/start-avd-with-cam.sh
@@ -1,0 +1,28 @@
+
+mknod /dev/video0 c 81 0
+chown root:video /dev/video0 && \
+chmod 660 /dev/video0
+
+if [ $? -ne 0 ]; then
+    echo "creating /dev/video failed -> did you modprobe 'modprobe v4l2loopback' on host? or does /dev/video0 exist on host?"
+    exit 1
+fi
+
+echo "woooot display $DISPLAY"
+ffmpeg -f x11grab -s 640x480 -i $DISPLAY -vf format=pix_fmts=yuv420p -f v4l2 /dev/video0 &
+
+
+export QTWEBENGINE_DISABLE_SANDBOX=1
+/usr/local/android-sdk/tools/emulator @Pixel -gpu off -camera-back webcam0
+
+sleep 10 && adb shell pm list packages | grep whatsapp &> /dev/null
+if [ $? == 0 ]; then
+    echo 'WhatsApp already installed'
+else
+    echo 'Installing WhatsApp'
+    adb install /app/whatsapp.apk
+fi
+
+sleep 5 && adb shell monkey -p com.whatsapp 1 
+
+exit 0

--- a/start-avd.sh
+++ b/start-avd.sh
@@ -1,3 +1,4 @@
+export QTWEBENGINE_DISABLE_SANDBOX=1
 /usr/local/android-sdk/tools/emulator @Pixel -gpu off
 
 sleep 10 && adb shell pm list packages | grep whatsapp &> /dev/null


### PR DESCRIPTION
new whatsapp apk, old one did work anymore and showed following error: "Date is inaccurate"
workaround that emulator don't crash when you click on left settings bar
new script to start with webcam support: start-avd-with-cam.sh
it shows the desktop in the camera, so was able to scan QR code from browser of whats app web (or in my case the matrix bridge client see https://github.com/tulir/mautrix-whatsapp/wiki/Android-VM-Setup)